### PR TITLE
[Feat]: item ver 1.3 추가

### DIFF
--- a/preprocessing/item_ver_1.3.ipynb
+++ b/preprocessing/item_ver_1.3.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "import os\n",
+    "sys.path.append(os.path.dirname(os.path.abspath(\".\")))\n",
+    "\n",
+    "import pandas as pd\n",
+    "from utils import GCSHelper\n",
+    "gcs_helper_preprocessed = GCSHelper(\"../keys/gcs_key.json\", bucket_name=\"maple_preprocessed_data\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'https://storage.googleapis.com/maple_web/image/item/1000000.png'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = gcs_helper_preprocessed.read_df_from_gcs(\"item_KMST_1149_VER1.2.csv\")\n",
+    "\n",
+    "# 아이템 이미지를 웹에서 바로 열어볼 수 있도록 변경\n",
+    "# maple_web이라는 새로운 버킷을 생성하고, 공개적으로 접근할 수 있도록 설정함\n",
+    "\n",
+    "df[\"gcs_image_url\"] = \"https://storage.googleapis.com/maple_web/\" + df[\"gcs_image_url\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gcs_helper_preprocessed.upload_df_to_gcs(\"item_KMST_1149_VER1.3.csv\", df)\n",
+    "gcs_helper_preprocessed.upload_df_to_gcs(\"item_KMST_1149_latest.csv\", df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "maple-project-TvhCNGkp-py3.8",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.15"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "6742150a18e3b067bc8ee708e6344dd27b020006aa64fa524d66282649c9a517"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
- gcs_image_url 변경
- 기존 버킷 내 파일 위치를 나타내던 것에서, 외부에서 접근 가능한 url로 변경
- 해당 컬럼의 값을 접속하면, 해당 아이템의 이미지가 나옴
- 자세한 내용은 노션 데이터 페이지 참고