### PR TITLE
Refactoring mcn

### DIFF
--- a/backend/src/AI/config/model_config.py
+++ b/backend/src/AI/config/model_config.py
@@ -6,14 +6,12 @@ MODEL_CONFIG = {
     },
     "MCN": {
         "model_path": "src/AI/save_model/MCN/MCN_latest.pt",
-        "embed_size": 512,
-        "need_rep": True,
-        "vse_off": True,
+        "embed_size": 128,
         "pe_off": False,
-        "mlp_layers": 2,
-        "conv_feats": "1234",
-        "pretrained": True,
+        "pretrained": False,
         "resnet_layer_num": 18,
+        "hidden_sizes": [128],
+        "item_num": 7
         "top_k": 10,
         "batch_size": 32,
     },

--- a/backend/src/AI/inference/mcn_inference.py
+++ b/backend/src/AI/inference/mcn_inference.py
@@ -44,15 +44,12 @@ class MCNInference:
             self.item_parts.append(item_part)
 
         self.model = MCN(
-            embed_size=self.model_config["embed_size"],
-            need_rep=self.model_config["need_rep"],
-            vocabulary=None,
-            vse_off=self.model_config["vse_off"],
-            pe_off=self.model_config["pe_off"],
-            mlp_layers=self.model_config["mlp_layers"],
-            conv_feats=self.model_config["conv_feats"],
-            pretrained=self.model_config["pretrained"],
-            resnet_layer_num=self.model_config["resnet_layer_num"],
+            embed_size=model_config["embed_size"],
+            pe_off=model_config["pe_off"],
+            pretrained=model_config["pretrained"],
+            resnet_layer_num=model_config["resnet_layer_num"],
+            hidden_sizes=model_coinfig["hidden_sizes"],
+            item_num=model_config["item_num"]
         )
 
         self.model.load_state_dict(
@@ -75,7 +72,7 @@ class MCNInference:
             images.append(self.image_tensors[equip_index])
 
         images = torch.stack(images).unsqueeze(0).to(self.device)
-        score, _, __, ___ = self.model.forward(images)
+        score, _, _ = self.model.forward(images)
         return float(score)
 
     @torch.no_grad()
@@ -121,7 +118,7 @@ class MCNInference:
             for batch_idx, batch in enumerate(dataloader_per_part):
                 # batch shape (batch, 7) == (16, 7)
                 images = self.image_tensors[batch]
-                output, _, _, _ = self.model(images.to(self.device))
+                output, _, _ = self.model(images.to(self.device))
                 result = [
                     (batch[i, part_idx], float(output[i]))
                     for i in range(batch.shape[0])
@@ -141,7 +138,7 @@ class MCNInference:
         for batch_idx, batch in enumerate(dataloader_for_product):
             # batch shape (batch, 7) == (16, 7)
             images = self.image_tensors[batch]
-            output, _, _, _ = self.model(images.to(self.device))
+            output, _, _ = self.model(images.to(self.device))
             result = [(batch[i, :], float(output[i])) for i in range(batch.shape[0])]
             codi_scores.extend(result)
 

--- a/backend/src/AI/models/model_object/mcn.py
+++ b/backend/src/AI/models/model_object/mcn.py
@@ -1,4 +1,4 @@
-import itertools
+from itertools import combinations_with_replacement
 
 import numpy as np
 import torch
@@ -13,67 +13,45 @@ from src.AI.models.model_object.resnet import get_resnet
 class MCN(nn.Module):
     def __init__(
         self,
-        embed_size=1000,
-        need_rep=False,
-        vocabulary=None,
-        vse_off=True,
+        embed_size=128,
         pe_off=False,
-        mlp_layers=2,
-        conv_feats="1234",
-        pretrained=True,
-        resnet_layer_num=18
+        pretrained=False,
+        resnet_layer_num=18,
+        hidden_sizes=[128],
+        item_num=7,
     ):
-        """The Multi-Layered Comparison Network (MCN) for outfit compatibility
-        prediction and diagnosis.
-        Args:
-            embed_size: the output embedding size of the cnn model, default 1000.
-            need_rep: whether to output representation of the layer before last fc
-                layer, whose size is 2048. This representation can be used for
-                compute the Visual Sementic Embedding (VSE) loss.
-            vocabulary: the counts of words in the polyvore dataset.
-            vse_off: whether use visual semantic embedding.
-            pe_off: whether use projected embedding.
-            mlp_layers: number of mlp layers used in the last predictor part.
-            conv_feats: decide which layer of conv features are used for comparision.
-        """
         super(MCN, self).__init__()
-        self.vse_off = vse_off
         self.pe_off = pe_off
         self.mlp_layers = mlp_layers
-        self.conv_feats = conv_feats
+        self.item_num = item_num
 
         print(f"using resnet{resnet_layer_num}...")
-        cnn = get_resnet(layer_num=resnet_layer_num, pretrained=pretrained, need_rep=need_rep)
-        cnn.fc = nn.Linear(cnn.fc.in_features, embed_size)
-        self.cnn = cnn
-        self.need_rep = need_rep
-        self.num_rela = 28 * len(conv_feats)
-        self.bn = nn.BatchNorm1d(
-            self.num_rela
-        )  # 5x5 relationship matrix have 25 elements
+        self.cnn = get_resnet(layer_num=resnet_layer_num, pretrained=pretrained)
+        self.cnn.fc = nn.Linear(cnn.fc.in_features, embed_size)
+        self.num_rela = 0
+        for i in range(1, item_num + 1):
+            self.num_rela += i
+        self.num_rela *= 4
+        self.bn = nn.BatchNorm1d(self.num_rela)
 
-        # Define predictor part
-        if self.mlp_layers > 0:
-            predictor = []
-            for _ in range(self.mlp_layers - 1):
-                linear = nn.Linear(self.num_rela, self.num_rela)
-                nn.init.xavier_uniform_(linear.weight)
-                nn.init.constant_(linear.bias, 0)
-                predictor.append(linear)
-                predictor.append(nn.ReLU())
-            linear = nn.Linear(self.num_rela, 1)
+        predictor = []
+        before_mlp_size = self.num_rela
+        for hidden_size in range(hidden_sizes):
+            linear = nn.Linear(before_mlp_size, hidden_size)
             nn.init.xavier_uniform_(linear.weight)
-            nn.init.constant_(linear.bias, 0)
             predictor.append(linear)
-            self.predictor = nn.Sequential(*predictor)
+            predictor.append(nn.ReLU())
+            before_mlp_size = hidden_size
+
+        linear = nn.Linear(before_mlp_size, 1)
+        nn.init.xavier_uniform_(linear.weight)
+        predictor.append(linear)
+        self.predictor = nn.Sequential(*predictor)
         self.sigmoid = nn.Sigmoid()
 
         nn.init.xavier_uniform_(cnn.fc.weight)
-        nn.init.constant_(cnn.fc.bias, 0)
+        # nn.init.constant_(cnn.fc.bias, 0)
 
-        # Type specified masks
-        # l1, l2, l3 is the masks for feature maps for the beginning layers
-        # not suffix one is for the last layer
         self.masks = nn.Embedding(28, embed_size)
         self.masks.weight.data.normal_(0.9, 0.7)
         self.masks_l1 = nn.Embedding(28, 64)
@@ -83,178 +61,70 @@ class MCN(nn.Module):
         self.masks_l3 = nn.Embedding(28, 256)
         self.masks_l3.weight.data.normal_(0.9, 0.7)
 
-        # Semantic embedding model
-        if not self.vse_off:
-            self.sem_embedding = nn.Embedding(vocabulary, 1000)
-        # Visual embedding model
-        self.image_embedding = nn.Linear(2048, 1000)
-
-        # Global average pooling layer
         self.ada_avgpool2d = nn.AdaptiveAvgPool2d((1, 1))
 
     def forward(self, images, names=None):
-        """
-        Args:
-            images: Outfit images with shape (N, T, C, H, W)
-            names: Description words of each item in outfit
-        Return:
-            out: Compatibility score
-            vse_loss: Visual Semantic Loss
-            tmasks_loss: mask loss to encourage a sparse mask
-            features_loss: regularize the feature vector to be normal
-        """
-        if self.need_rep:
-            out, features, tmasks, rep = self._compute_score(images)
-        else:
-            out, features, tmasks = self._compute_score(images)
+        out, features, tmasks, rep = self._compute_score(images)
 
-        if self.vse_off:
-            vse_loss = torch.tensor(0.0)
-        else:
-            vse_loss = self._compute_vse_loss(names, rep)
         if self.pe_off:
             tmasks_loss, features_loss = torch.tensor(0.0), torch.tensor(0.0)
         else:
             tmasks_loss, features_loss = self._compute_type_repr_loss(tmasks, features)
 
-        return out, vse_loss, tmasks_loss, features_loss
-
-    def _compute_vse_loss(self, names, rep):
-        """Visual semantice loss which map both visual embedding and semantic embedding
-        into a common space.
-        Reference:
-        https://github.com/xthan/polyvore/blob/e0ca93b0671491564b4316982d4bfe7da17b6238/polyvore/polyvore_model_bi.py#L362
-        """
-        # Normalized Semantic Embedding
-        padded_names = rnn_utils.pad_sequence(names, batch_first=True).to(rep.device)
-        mask = torch.gt(padded_names, 0)
-        cap_mask = torch.ge(mask.sum(dim=1), 2)
-        semb = self.sem_embedding(padded_names)
-        semb = semb * (mask.unsqueeze(dim=2)).float()
-        word_lengths = mask.sum(dim=1)
-        word_lengths = torch.where(
-            word_lengths == 0,
-            (torch.ones(semb.shape[0]).float() * 0.1).to(rep.device),
-            word_lengths.float(),
-        )
-        semb = semb.sum(dim=1) / word_lengths.unsqueeze(dim=1)
-        semb = F.normalize(semb, dim=1)
-
-        # Normalized Visual Embedding
-        vemb = F.normalize(self.image_embedding(rep), dim=1)
-
-        # VSE Loss
-        semb = torch.masked_select(semb, cap_mask.unsqueeze(dim=1))
-        vemb = torch.masked_select(vemb, cap_mask.unsqueeze(dim=1))
-        semb = semb.reshape([-1, 1000])
-        vemb = vemb.reshape([-1, 1000])
-        scores = torch.matmul(semb, vemb.transpose(0, 1))
-        diagnoal = scores.diag().unsqueeze(dim=1)
-        cost_s = torch.clamp(0.2 - diagnoal + scores, min=0, max=1e6)  # 0.2 is margin
-        cost_im = torch.clamp(0.2 - diagnoal.transpose(0, 1) + scores, min=0, max=1e6)
-        cost_s = cost_s - torch.diag(cost_s.diag())
-        cost_im = cost_im - torch.diag(cost_im.diag())
-        vse_loss = cost_s.sum() + cost_im.sum()
-        vse_loss = vse_loss / (semb.shape[0] ** 2)
-
-        return vse_loss
+        return out, tmasks_loss, features_loss
 
     def _compute_type_repr_loss(self, tmasks, features):
-        """Here adopt two losses to improve the type-spcified represetations.
-        `tmasks_loss` expect the masks to be sparse and `features_loss` regularize
-        the feature vector to be a unit vector.
-        Reference:
-        Conditional Similarity Networks: https://arxiv.org/abs/1603.07810
-        """
         # Type embedding loss
         tmasks_loss = tmasks.norm(1) / len(tmasks)
-        features_loss = features.norm(2) / np.sqrt(
-            (features.shape[0] * features.shape[1])
-        )
+        features_loss = features.norm(2) / np.sqrt((features.shape[0] * features.shape[1]))
+
         return tmasks_loss, features_loss
 
     def _compute_score(self, images, activate=True):
-        """Extract feature vectors from input images.
-        Return:
-            out: the compatibility score
-            features: the visual embedding of the images, we use 1000-d in all experiments
-            masks: the mask for type-specified embedding
-            rep: the represtions of the second last year, which is 2048-d for resnet-50 backend
-        """
-        batch_size, item_num, _, _, img_size = images.shape
-        images = torch.reshape(images, (-1, 3, img_size, img_size))
-        if self.need_rep:
-            features, *rep = self.cnn(images)
-            rep_l1, rep_l2, rep_l3, rep_l4, rep = rep
-        else:
-            features = self.cnn(images)
+        batch_size, item_num, channels, h, w = images.shape
+        images = torch.reshape(images, (-1, channels, h, w))
+
+        features, rep_l1, rep_l2, rep_l3, rep_l4, rep  = self.cnn(images)
 
         relations = []
-        features = features.reshape(batch_size, item_num, -1)  # (32, 5, 1000)
+        features = features.reshape(batch_size, item_num, -1)
         masks = F.relu(self.masks.weight)
-        # Comparison matrix
-        if "4" in self.conv_feats:
-            for mi, (i, j) in enumerate(
-                itertools.combinations_with_replacement([0, 1, 2, 3, 4, 5, 6], 2)
-            ):
-                if self.pe_off:
-                    left = F.normalize(
-                        features[:, i : i + 1, :], dim=-1
-                    )  # (32, 1, 1000)
-                    right = F.normalize(features[:, j : j + 1, :], dim=-1)
-                else:
-                    left = F.normalize(
-                        masks[mi] * features[:, i : i + 1, :], dim=-1
-                    )  # (32, 1, 1000)
-                    right = F.normalize(masks[mi] * features[:, j : j + 1, :], dim=-1)
-                rela = torch.matmul(left, right.transpose(1, 2)).squeeze()  # (32)
-                relations.append(rela)
 
-        # Comparision at Multi-Layered representations
-        rep_list = []
-        masks_list = []
-        if "1" in self.conv_feats:
-            rep_list.append(rep_l1)
-            masks_list.append(self.masks_l1)
-        if "2" in self.conv_feats:
-            rep_list.append(rep_l2)
-            masks_list.append(self.masks_l2)
-        if "3" in self.conv_feats:
-            rep_list.append(rep_l3)
-            masks_list.append(self.masks_l3)
+        for mi, (item_i, item_j) in enumerate(combinations_with_replacement([i for i in range(self.item_num)], 2)):
+            if self.pe_off:
+                left = F.normalize(features[:, item_i, :], dim=-1)
+                right = F.normalize(features[:, item_j, :], dim=-1)
+            else:
+                left = F.normalize(masks[mi] * features[:, item_i:item_i + 1, :], dim=-1)
+                right = F.normalize(masks[mi] * features[:, item_j:item_j + 1, :], dim=-1)
+            rela = torch.matmul(left, right.transpose(1, 2)).squeeze()
+            relations.append(rela)
+
+        rep_list, masks_list = list(), list()
+
+        rep_list.append(rep_l1)
+        masks_list.append(self.masks_l1)
+        rep_list.append(rep_l2)
+        masks_list.append(self.masks_l2)
+        rep_list.append(rep_l3)
+        masks_list.append(self.masks_l3)
+
         for rep_li, masks_li in zip(rep_list, masks_list):
-            rep_li = (
-                self.ada_avgpool2d(rep_li).squeeze().reshape(batch_size, item_num, -1)
-            )
-            masks_li = F.relu(masks_li.weight)
-            # Enumerate all pairwise combination among the outfit then compare their features
-            for mi, (i, j) in enumerate(
-                itertools.combinations_with_replacement([0, 1, 2, 3, 4, 5, 6], 2)
-            ):
-                if self.pe_off:
-                    left = F.normalize(masks_li[mi] * rep_li[:, i:i + 1, :], dim=-1)  # (32, 1, 1000)
-                    right = F.normalize(masks_li[mi] * rep_li[:, j:j + 1, :], dim=-1)
-                else:
-                    left = F.normalize(masks_li[mi] * rep_li[:, i:i + 1, :], dim=-1)  # (32, 1, 1000)
-                    right = F.normalize(masks_li[mi] * rep_li[:, j:j + 1, :], dim=-1)
-                rela = torch.matmul(left, right.transpose(1, 2)).squeeze()  # (32)
+            rep_li = (self.ada_avgpool2d(rep_li).squeeze().reshape(batch_size, item_num, -1))
+
+            for mi, (i, j) in enumerate(combinations_with_replacement([i for i in range(self.item_num)], 2)):
+                left = F.normalize(masks_li[mi] * rep_li[:, i, :], dim=-1)
+                right = F.normalize(masks_li[mi] * rep_li[:, j, :], dim=-1)
+                rela = torch.matmul(left, right.transpose(1, 2)).squeeze()
                 relations.append(rela)
 
-        if batch_size == 1:  # Inference during evaluation, which input one sample
+        if batch_size == 1:
             relations = torch.stack(relations).unsqueeze(0)
         else:
-            relations = torch.stack(relations, dim=1)  # (32 ,15*4)
+            relations = torch.stack(relations, dim=1)
         relations = self.bn(relations)
 
-        # Predictor
-        if self.mlp_layers == 0:
-            out = relations.mean(dim=-1, keepdim=True)
-        else:
-            out = self.predictor(relations)
+        out = self.predictor(relations)
+        out = self.sigmoid(out)
 
-        if activate:
-            out = self.sigmoid(out)
-        if self.need_rep:
-            return out, features, masks, rep
-        else:
-            return out, features, masks
+        return out, features, masks, rep

--- a/backend/src/AI/models/model_object/resnet.py
+++ b/backend/src/AI/models/model_object/resnet.py
@@ -1,17 +1,6 @@
 import torch.nn as nn
 import torch.utils.model_zoo as model_zoo
 
-__all__ = ["ResNet", "resnet18", "resnet34", "resnet50", "resnet101", "resnet152"]
-
-
-model_urls = {
-    "resnet18": "https://download.pytorch.org/models/resnet18-5c106cde.pth",
-    "resnet34": "https://download.pytorch.org/models/resnet34-333f7ec4.pth",
-    "resnet50": "https://download.pytorch.org/models/resnet50-19c8e357.pth",
-    "resnet101": "https://download.pytorch.org/models/resnet101-5d3b4d8f.pth",
-    "resnet152": "https://download.pytorch.org/models/resnet152-b121ed2d.pth",
-}
-
 
 def get_resnet(layer_num, pretrained, need_rep):
     if not layer_num in [18, 34, 50, 101, 152]:
@@ -48,18 +37,26 @@ def conv1x1(in_planes, out_planes, stride=1):
 class BasicBlock(nn.Module):
     expansion = 1
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
         super(BasicBlock, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        if groups != 1 or base_width != 64:
+            raise ValueError('BasicBlock only supports groups=1 and base_width=64')
+        if dilation > 1:
+            raise NotImplementedError("Dilation > 1 not supported in BasicBlock")
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
         self.conv1 = conv3x3(inplanes, planes, stride)
-        self.bn1 = nn.BatchNorm2d(planes)
+        self.bn1 = norm_layer(planes)
         self.relu = nn.ReLU(inplace=True)
         self.conv2 = conv3x3(planes, planes)
-        self.bn2 = nn.BatchNorm2d(planes)
+        self.bn2 = norm_layer(planes)
         self.downsample = downsample
         self.stride = stride
 
     def forward(self, x):
-        residual = x
+        identity = x
 
         out = self.conv1(x)
         out = self.bn1(out)
@@ -69,9 +66,9 @@ class BasicBlock(nn.Module):
         out = self.bn2(out)
 
         if self.downsample is not None:
-            residual = self.downsample(x)
+            identity = self.downsample(x)
 
-        out += residual
+        out += identity
         out = self.relu(out)
 
         return out
@@ -79,21 +76,24 @@ class BasicBlock(nn.Module):
 
 class Bottleneck(nn.Module):
     expansion = 4
-
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
         super(Bottleneck, self).__init__()
-        self.conv1 = conv1x1(inplanes, planes)
-        self.bn1 = nn.BatchNorm2d(planes)
-        self.conv2 = conv3x3(planes, planes, stride)
-        self.bn2 = nn.BatchNorm2d(planes)
-        self.conv3 = conv1x1(planes, planes * self.expansion)
-        self.bn3 = nn.BatchNorm2d(planes * self.expansion)
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        width = int(planes * (base_width / 64.)) * groups
+        self.conv1 = conv1x1(inplanes, width)
+        self.bn1 = norm_layer(width)
+        self.conv2 = conv3x3(width, width, stride, groups, dilation)
+        self.bn2 = norm_layer(width)
+        self.conv3 = conv1x1(width, planes * self.expansion)
+        self.bn3 = norm_layer(planes * self.expansion)
         self.relu = nn.ReLU(inplace=True)
         self.downsample = downsample
         self.stride = stride
 
     def forward(self, x):
-        residual = x
+        identity = x
 
         out = self.conv1(x)
         out = self.bn1(out)
@@ -107,50 +107,90 @@ class Bottleneck(nn.Module):
         out = self.bn3(out)
 
         if self.downsample is not None:
-            residual = self.downsample(x)
+            identity = self.downsample(x)
 
-        out += residual
+        out += identity
         out = self.relu(out)
 
         return out
 
 
 class ResNet(nn.Module):
-    def __init__(self, block, layers, num_classes=1000, need_rep=False):
-        self.inplanes = 64
+    def __init__(
+            self,
+            block,
+            layers,
+            num_classes=1000,
+            zero_init_residual=False,
+            groups=1,
+            width_per_group=64,
+            replace_stride_with_dilation=None,
+            norm_layer=None
+    ):
         super(ResNet, self).__init__()
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
-        self.bn1 = nn.BatchNorm2d(64)
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError("replace_stride_with_dilation should be None "
+                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = nn.Conv2d(3, self.inplanes, kernel_size=7, stride=2, padding=3,
+                               bias=False)
+        self.bn1 = norm_layer(self.inplanes)
         self.relu = nn.ReLU(inplace=True)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
         self.layer1 = self._make_layer(block, 64, layers[0])
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2,
+                                       dilate=replace_stride_with_dilation[0])
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2,
+                                       dilate=replace_stride_with_dilation[1])
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
+                                       dilate=replace_stride_with_dilation[2])
         self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.fc = nn.Linear(512 * block.expansion, num_classes)
-        self.need_rep = need_rep
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
-                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
-            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
                 nn.init.constant_(m.weight, 1)
                 nn.init.constant_(m.bias, 0)
 
-    def _make_layer(self, block, planes, blocks, stride=1):
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck):
+                    nn.init.constant_(m.bn3.weight, 0)
+                elif isinstance(m, BasicBlock):
+                    nn.init.constant_(m.bn2.weight, 0)
+
+    def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
+        norm_layer = self._norm_layer
         downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
         if stride != 1 or self.inplanes != planes * block.expansion:
             downsample = nn.Sequential(
                 conv1x1(self.inplanes, planes * block.expansion, stride),
-                nn.BatchNorm2d(planes * block.expansion),
+                norm_layer(planes * block.expansion),
             )
 
         layers = []
-        layers.append(block(self.inplanes, planes, stride, downsample))
+        layers.append(block(self.inplanes, planes, stride, downsample, self.groups,
+                            self.base_width, previous_dilation, norm_layer))
         self.inplanes = planes * block.expansion
         for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes))
+            layers.append(block(self.inplanes, planes, groups=self.groups,
+                                base_width=self.base_width, dilation=self.dilation,
+                                norm_layer=norm_layer))
 
         return nn.Sequential(*layers)
 
@@ -173,11 +213,7 @@ class ResNet(nn.Module):
         rep = x.view(x.size(0), -1)
         x = self.fc(rep)
 
-        if self.need_rep:
-            # return x, rep
-            return x, rep_l1, rep_l2, rep_l3, rep_l4, rep
-        else:
-            return x
+        return x, rep_l1, rep_l2, rep_l3, rep_l4, rep
 
 
 def resnet18(pretrained=False, **kwargs):
@@ -193,43 +229,47 @@ def resnet18(pretrained=False, **kwargs):
 
 def resnet34(pretrained=False, **kwargs):
     """Constructs a ResNet-34 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(BasicBlock, [3, 4, 6, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet34"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet34']))
     return model
 
 
 def resnet50(pretrained=False, **kwargs):
     """Constructs a ResNet-50 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(Bottleneck, [3, 4, 6, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet50"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet50']))
     return model
 
 
 def resnet101(pretrained=False, **kwargs):
     """Constructs a ResNet-101 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(Bottleneck, [3, 4, 23, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet101"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet101']))
     return model
 
 
 def resnet152(pretrained=False, **kwargs):
     """Constructs a ResNet-152 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(Bottleneck, [3, 8, 36, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet152"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet152']))
     return model

--- a/modeling/config/MCN_config.json
+++ b/modeling/config/MCN_config.json
@@ -39,14 +39,12 @@
   "arch": {
     "type": "MCN",
     "args": {
-      "embed_size": 512,
-      "need_rep": true,
-      "vse_off": true,
+      "embed_size": 128,
       "pe_off": false,
-      "mlp_layers": 2,
-      "conv_feats": "1234",
-      "pretrained": true,
-      "resnet_layer_num": 18
+      "pretrained": false,
+      "resnet_layer_num": 18,
+      "hidden_sizes": [128],
+      "item_num": 7
     }
   },
   "inference": {

--- a/modeling/model/get_model.py
+++ b/modeling/model/get_model.py
@@ -18,14 +18,11 @@ def get_models(config: Dict[str, Any]) -> nn.Module:
         model_config = config["arch"]["args"]
         model = getattr(models, config["arch"]["type"])(
             embed_size=model_config["embed_size"],
-            need_rep=model_config["need_rep"],
-            vocabulary=None,
-            vse_off=model_config["vse_off"],
             pe_off=model_config["pe_off"],
-            mlp_layers=model_config["mlp_layers"],
-            conv_feats=model_config["conv_feats"],
             pretrained=model_config["pretrained"],
             resnet_layer_num=model_config["resnet_layer_num"],
+            hidden_sizes=model_coinfig["hidden_sizes"],
+            item_num=model_config["item_num"]
         )
     else:
         raise NotImplementedError

--- a/modeling/model/mcn.py
+++ b/modeling/model/mcn.py
@@ -1,4 +1,4 @@
-import itertools
+from itertools import combinations_with_replacement
 
 import numpy as np
 import torch
@@ -13,67 +13,45 @@ from modeling.model.resnet import get_resnet
 class MCN(nn.Module):
     def __init__(
         self,
-        embed_size=1000,
-        need_rep=False,
-        vocabulary=None,
-        vse_off=True,
+        embed_size=128,
         pe_off=False,
-        mlp_layers=2,
-        conv_feats="1234",
-        pretrained=True,
-        resnet_layer_num=50
+        pretrained=False,
+        resnet_layer_num=18,
+        hidden_sizes=[128],
+        item_num=7,
     ):
-        """The Multi-Layered Comparison Network (MCN) for outfit compatibility
-        prediction and diagnosis.
-        Args:
-            embed_size: the output embedding size of the cnn model, default 1000.
-            need_rep: whether to output representation of the layer before last fc
-                layer, whose size is 2048. This representation can be used for
-                compute the Visual Sementic Embedding (VSE) loss.
-            vocabulary: the counts of words in the polyvore dataset.
-            vse_off: whether use visual semantic embedding.
-            pe_off: whether use projected embedding.
-            mlp_layers: number of mlp layers used in the last predictor part.
-            conv_feats: decide which layer of conv features are used for comparision.
-        """
         super(MCN, self).__init__()
-        self.vse_off = vse_off
         self.pe_off = pe_off
         self.mlp_layers = mlp_layers
-        self.conv_feats = conv_feats
+        self.item_num = item_num
 
         print(f"using resnet{resnet_layer_num}...")
-        cnn = get_resnet(layer_num=resnet_layer_num, pretrained=pretrained, need_rep=need_rep)
-        cnn.fc = nn.Linear(cnn.fc.in_features, embed_size)
-        self.cnn = cnn
-        self.need_rep = need_rep
-        self.num_rela = 28 * len(conv_feats)
-        self.bn = nn.BatchNorm1d(
-            self.num_rela
-        )  # 5x5 relationship matrix have 25 elements
+        self.cnn = get_resnet(layer_num=resnet_layer_num, pretrained=pretrained)
+        self.cnn.fc = nn.Linear(cnn.fc.in_features, embed_size)
+        self.num_rela = 0
+        for i in range(1, item_num + 1):
+            self.num_rela += i
+        self.num_rela *= 4
+        self.bn = nn.BatchNorm1d(self.num_rela)
 
-        # Define predictor part
-        if self.mlp_layers > 0:
-            predictor = []
-            for _ in range(self.mlp_layers - 1):
-                linear = nn.Linear(self.num_rela, self.num_rela)
-                nn.init.xavier_uniform_(linear.weight)
-                nn.init.constant_(linear.bias, 0)
-                predictor.append(linear)
-                predictor.append(nn.ReLU())
-            linear = nn.Linear(self.num_rela, 1)
+        predictor = []
+        before_mlp_size = self.num_rela
+        for hidden_size in range(hidden_sizes):
+            linear = nn.Linear(before_mlp_size, hidden_size)
             nn.init.xavier_uniform_(linear.weight)
-            nn.init.constant_(linear.bias, 0)
             predictor.append(linear)
-            self.predictor = nn.Sequential(*predictor)
+            predictor.append(nn.ReLU())
+            before_mlp_size = hidden_size
+
+        linear = nn.Linear(before_mlp_size, 1)
+        nn.init.xavier_uniform_(linear.weight)
+        predictor.append(linear)
+        self.predictor = nn.Sequential(*predictor)
         self.sigmoid = nn.Sigmoid()
 
         nn.init.xavier_uniform_(cnn.fc.weight)
-        nn.init.constant_(cnn.fc.bias, 0)
+        # nn.init.constant_(cnn.fc.bias, 0)
 
-        # Type specified masks
-        # l1, l2, l3 is the masks for feature maps for the beginning layers
-        # not suffix one is for the last layer
         self.masks = nn.Embedding(28, embed_size)
         self.masks.weight.data.normal_(0.9, 0.7)
         self.masks_l1 = nn.Embedding(28, 64)
@@ -83,178 +61,70 @@ class MCN(nn.Module):
         self.masks_l3 = nn.Embedding(28, 256)
         self.masks_l3.weight.data.normal_(0.9, 0.7)
 
-        # Semantic embedding model
-        if not self.vse_off:
-            self.sem_embedding = nn.Embedding(vocabulary, 1000)
-        # Visual embedding model
-        self.image_embedding = nn.Linear(2048, 1000)
-
-        # Global average pooling layer
         self.ada_avgpool2d = nn.AdaptiveAvgPool2d((1, 1))
 
     def forward(self, images, names=None):
-        """
-        Args:
-            images: Outfit images with shape (N, T, C, H, W)
-            names: Description words of each item in outfit
-        Return:
-            out: Compatibility score
-            vse_loss: Visual Semantic Loss
-            tmasks_loss: mask loss to encourage a sparse mask
-            features_loss: regularize the feature vector to be normal
-        """
-        if self.need_rep:
-            out, features, tmasks, rep = self._compute_score(images)
-        else:
-            out, features, tmasks = self._compute_score(images)
+        out, features, tmasks, rep = self._compute_score(images)
 
-        if self.vse_off:
-            vse_loss = torch.tensor(0.0)
-        else:
-            vse_loss = self._compute_vse_loss(names, rep)
         if self.pe_off:
             tmasks_loss, features_loss = torch.tensor(0.0), torch.tensor(0.0)
         else:
             tmasks_loss, features_loss = self._compute_type_repr_loss(tmasks, features)
 
-        return out, vse_loss, tmasks_loss, features_loss
-
-    def _compute_vse_loss(self, names, rep):
-        """Visual semantice loss which map both visual embedding and semantic embedding
-        into a common space.
-        Reference:
-        https://github.com/xthan/polyvore/blob/e0ca93b0671491564b4316982d4bfe7da17b6238/polyvore/polyvore_model_bi.py#L362
-        """
-        # Normalized Semantic Embedding
-        padded_names = rnn_utils.pad_sequence(names, batch_first=True).to(rep.device)
-        mask = torch.gt(padded_names, 0)
-        cap_mask = torch.ge(mask.sum(dim=1), 2)
-        semb = self.sem_embedding(padded_names)
-        semb = semb * (mask.unsqueeze(dim=2)).float()
-        word_lengths = mask.sum(dim=1)
-        word_lengths = torch.where(
-            word_lengths == 0,
-            (torch.ones(semb.shape[0]).float() * 0.1).to(rep.device),
-            word_lengths.float(),
-        )
-        semb = semb.sum(dim=1) / word_lengths.unsqueeze(dim=1)
-        semb = F.normalize(semb, dim=1)
-
-        # Normalized Visual Embedding
-        vemb = F.normalize(self.image_embedding(rep), dim=1)
-
-        # VSE Loss
-        semb = torch.masked_select(semb, cap_mask.unsqueeze(dim=1))
-        vemb = torch.masked_select(vemb, cap_mask.unsqueeze(dim=1))
-        semb = semb.reshape([-1, 1000])
-        vemb = vemb.reshape([-1, 1000])
-        scores = torch.matmul(semb, vemb.transpose(0, 1))
-        diagnoal = scores.diag().unsqueeze(dim=1)
-        cost_s = torch.clamp(0.2 - diagnoal + scores, min=0, max=1e6)  # 0.2 is margin
-        cost_im = torch.clamp(0.2 - diagnoal.transpose(0, 1) + scores, min=0, max=1e6)
-        cost_s = cost_s - torch.diag(cost_s.diag())
-        cost_im = cost_im - torch.diag(cost_im.diag())
-        vse_loss = cost_s.sum() + cost_im.sum()
-        vse_loss = vse_loss / (semb.shape[0] ** 2)
-
-        return vse_loss
+        return out, tmasks_loss, features_loss
 
     def _compute_type_repr_loss(self, tmasks, features):
-        """Here adopt two losses to improve the type-spcified represetations.
-        `tmasks_loss` expect the masks to be sparse and `features_loss` regularize
-        the feature vector to be a unit vector.
-        Reference:
-        Conditional Similarity Networks: https://arxiv.org/abs/1603.07810
-        """
         # Type embedding loss
         tmasks_loss = tmasks.norm(1) / len(tmasks)
-        features_loss = features.norm(2) / np.sqrt(
-            (features.shape[0] * features.shape[1])
-        )
+        features_loss = features.norm(2) / np.sqrt((features.shape[0] * features.shape[1]))
+
         return tmasks_loss, features_loss
 
     def _compute_score(self, images, activate=True):
-        """Extract feature vectors from input images.
-        Return:
-            out: the compatibility score
-            features: the visual embedding of the images, we use 1000-d in all experiments
-            masks: the mask for type-specified embedding
-            rep: the represtions of the second last year, which is 2048-d for resnet-50 backend
-        """
-        batch_size, item_num, _, _, img_size = images.shape
-        images = torch.reshape(images, (-1, 3, img_size, img_size))
-        if self.need_rep:
-            features, *rep = self.cnn(images)
-            rep_l1, rep_l2, rep_l3, rep_l4, rep = rep
-        else:
-            features = self.cnn(images)
+        batch_size, item_num, channels, h, w = images.shape
+        images = torch.reshape(images, (-1, channels, h, w))
+
+        features, rep_l1, rep_l2, rep_l3, rep_l4, rep  = self.cnn(images)
 
         relations = []
-        features = features.reshape(batch_size, item_num, -1)  # (32, 5, 1000)
+        features = features.reshape(batch_size, item_num, -1)
         masks = F.relu(self.masks.weight)
-        # Comparison matrix
-        if "4" in self.conv_feats:
-            for mi, (i, j) in enumerate(
-                itertools.combinations_with_replacement([0, 1, 2, 3, 4, 5, 6], 2)
-            ):
-                if self.pe_off:
-                    left = F.normalize(
-                        features[:, i : i + 1, :], dim=-1
-                    )  # (32, 1, 1000)
-                    right = F.normalize(features[:, j : j + 1, :], dim=-1)
-                else:
-                    left = F.normalize(
-                        masks[mi] * features[:, i : i + 1, :], dim=-1
-                    )  # (32, 1, 1000)
-                    right = F.normalize(masks[mi] * features[:, j : j + 1, :], dim=-1)
-                rela = torch.matmul(left, right.transpose(1, 2)).squeeze()  # (32)
-                relations.append(rela)
 
-        # Comparision at Multi-Layered representations
-        rep_list = []
-        masks_list = []
-        if "1" in self.conv_feats:
-            rep_list.append(rep_l1)
-            masks_list.append(self.masks_l1)
-        if "2" in self.conv_feats:
-            rep_list.append(rep_l2)
-            masks_list.append(self.masks_l2)
-        if "3" in self.conv_feats:
-            rep_list.append(rep_l3)
-            masks_list.append(self.masks_l3)
+        for mi, (item_i, item_j) in enumerate(combinations_with_replacement([i for i in range(self.item_num)], 2)):
+            if self.pe_off:
+                left = F.normalize(features[:, item_i, :], dim=-1)
+                right = F.normalize(features[:, item_j, :], dim=-1)
+            else:
+                left = F.normalize(masks[mi] * features[:, item_i:item_i + 1, :], dim=-1)
+                right = F.normalize(masks[mi] * features[:, item_j:item_j + 1, :], dim=-1)
+            rela = torch.matmul(left, right.transpose(1, 2)).squeeze()
+            relations.append(rela)
+
+        rep_list, masks_list = list(), list()
+
+        rep_list.append(rep_l1)
+        masks_list.append(self.masks_l1)
+        rep_list.append(rep_l2)
+        masks_list.append(self.masks_l2)
+        rep_list.append(rep_l3)
+        masks_list.append(self.masks_l3)
+
         for rep_li, masks_li in zip(rep_list, masks_list):
-            rep_li = (
-                self.ada_avgpool2d(rep_li).squeeze().reshape(batch_size, item_num, -1)
-            )
-            masks_li = F.relu(masks_li.weight)
-            # Enumerate all pairwise combination among the outfit then compare their features
-            for mi, (i, j) in enumerate(
-                itertools.combinations_with_replacement([0, 1, 2, 3, 4, 5, 6], 2)
-            ):
-                if self.pe_off:
-                    left = F.normalize(masks_li[mi] * rep_li[:, i:i + 1, :], dim=-1)  # (32, 1, 1000)
-                    right = F.normalize(masks_li[mi] * rep_li[:, j:j + 1, :], dim=-1)
-                else:
-                    left = F.normalize(masks_li[mi] * rep_li[:, i:i + 1, :], dim=-1)  # (32, 1, 1000)
-                    right = F.normalize(masks_li[mi] * rep_li[:, j:j + 1, :], dim=-1)
-                rela = torch.matmul(left, right.transpose(1, 2)).squeeze()  # (32)
+            rep_li = (self.ada_avgpool2d(rep_li).squeeze().reshape(batch_size, item_num, -1))
+
+            for mi, (i, j) in enumerate(combinations_with_replacement([i for i in range(self.item_num)], 2)):
+                left = F.normalize(masks_li[mi] * rep_li[:, i, :], dim=-1)
+                right = F.normalize(masks_li[mi] * rep_li[:, j, :], dim=-1)
+                rela = torch.matmul(left, right.transpose(1, 2)).squeeze()
                 relations.append(rela)
 
-        if batch_size == 1:  # Inference during evaluation, which input one sample
+        if batch_size == 1:
             relations = torch.stack(relations).unsqueeze(0)
         else:
-            relations = torch.stack(relations, dim=1)  # (32 ,15*4)
+            relations = torch.stack(relations, dim=1)
         relations = self.bn(relations)
 
-        # Predictor
-        if self.mlp_layers == 0:
-            out = relations.mean(dim=-1, keepdim=True)
-        else:
-            out = self.predictor(relations)
+        out = self.predictor(relations)
+        out = self.sigmoid(out)
 
-        if activate:
-            out = self.sigmoid(out)
-        if self.need_rep:
-            return out, features, masks, rep
-        else:
-            return out, features, masks
+        return out, features, masks, rep

--- a/modeling/model/resnet.py
+++ b/modeling/model/resnet.py
@@ -1,16 +1,6 @@
 import torch.nn as nn
 import torch.utils.model_zoo as model_zoo
 
-__all__ = ["ResNet", "resnet18", "resnet34", "resnet50", "resnet101", "resnet152"]
-
-
-model_urls = {
-    "resnet18": "https://download.pytorch.org/models/resnet18-5c106cde.pth",
-    "resnet34": "https://download.pytorch.org/models/resnet34-333f7ec4.pth",
-    "resnet50": "https://download.pytorch.org/models/resnet50-19c8e357.pth",
-    "resnet101": "https://download.pytorch.org/models/resnet101-5d3b4d8f.pth",
-    "resnet152": "https://download.pytorch.org/models/resnet152-b121ed2d.pth",
-}
 
 def get_resnet(layer_num, pretrained, need_rep):
     if not layer_num in [18, 34, 50, 101, 152]:
@@ -47,18 +37,26 @@ def conv1x1(in_planes, out_planes, stride=1):
 class BasicBlock(nn.Module):
     expansion = 1
 
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
         super(BasicBlock, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        if groups != 1 or base_width != 64:
+            raise ValueError('BasicBlock only supports groups=1 and base_width=64')
+        if dilation > 1:
+            raise NotImplementedError("Dilation > 1 not supported in BasicBlock")
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
         self.conv1 = conv3x3(inplanes, planes, stride)
-        self.bn1 = nn.BatchNorm2d(planes)
+        self.bn1 = norm_layer(planes)
         self.relu = nn.ReLU(inplace=True)
         self.conv2 = conv3x3(planes, planes)
-        self.bn2 = nn.BatchNorm2d(planes)
+        self.bn2 = norm_layer(planes)
         self.downsample = downsample
         self.stride = stride
 
     def forward(self, x):
-        residual = x
+        identity = x
 
         out = self.conv1(x)
         out = self.bn1(out)
@@ -68,9 +66,9 @@ class BasicBlock(nn.Module):
         out = self.bn2(out)
 
         if self.downsample is not None:
-            residual = self.downsample(x)
+            identity = self.downsample(x)
 
-        out += residual
+        out += identity
         out = self.relu(out)
 
         return out
@@ -78,21 +76,24 @@ class BasicBlock(nn.Module):
 
 class Bottleneck(nn.Module):
     expansion = 4
-
-    def __init__(self, inplanes, planes, stride=1, downsample=None):
+    def __init__(self, inplanes, planes, stride=1, downsample=None, groups=1,
+                 base_width=64, dilation=1, norm_layer=None):
         super(Bottleneck, self).__init__()
-        self.conv1 = conv1x1(inplanes, planes)
-        self.bn1 = nn.BatchNorm2d(planes)
-        self.conv2 = conv3x3(planes, planes, stride)
-        self.bn2 = nn.BatchNorm2d(planes)
-        self.conv3 = conv1x1(planes, planes * self.expansion)
-        self.bn3 = nn.BatchNorm2d(planes * self.expansion)
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        width = int(planes * (base_width / 64.)) * groups
+        self.conv1 = conv1x1(inplanes, width)
+        self.bn1 = norm_layer(width)
+        self.conv2 = conv3x3(width, width, stride, groups, dilation)
+        self.bn2 = norm_layer(width)
+        self.conv3 = conv1x1(width, planes * self.expansion)
+        self.bn3 = norm_layer(planes * self.expansion)
         self.relu = nn.ReLU(inplace=True)
         self.downsample = downsample
         self.stride = stride
 
     def forward(self, x):
-        residual = x
+        identity = x
 
         out = self.conv1(x)
         out = self.bn1(out)
@@ -106,50 +107,90 @@ class Bottleneck(nn.Module):
         out = self.bn3(out)
 
         if self.downsample is not None:
-            residual = self.downsample(x)
+            identity = self.downsample(x)
 
-        out += residual
+        out += identity
         out = self.relu(out)
 
         return out
 
 
 class ResNet(nn.Module):
-    def __init__(self, block, layers, num_classes=1000, need_rep=False):
-        self.inplanes = 64
+    def __init__(
+            self,
+            block,
+            layers,
+            num_classes=1000,
+            zero_init_residual=False,
+            groups=1,
+            width_per_group=64,
+            replace_stride_with_dilation=None,
+            norm_layer=None
+    ):
         super(ResNet, self).__init__()
-        self.conv1 = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3, bias=False)
-        self.bn1 = nn.BatchNorm2d(64)
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError("replace_stride_with_dilation should be None "
+                             "or a 3-element tuple, got {}".format(replace_stride_with_dilation))
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = nn.Conv2d(3, self.inplanes, kernel_size=7, stride=2, padding=3,
+                               bias=False)
+        self.bn1 = norm_layer(self.inplanes)
         self.relu = nn.ReLU(inplace=True)
         self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
         self.layer1 = self._make_layer(block, 64, layers[0])
-        self.layer2 = self._make_layer(block, 128, layers[1], stride=2)
-        self.layer3 = self._make_layer(block, 256, layers[2], stride=2)
-        self.layer4 = self._make_layer(block, 512, layers[3], stride=2)
+        self.layer2 = self._make_layer(block, 128, layers[1], stride=2,
+                                       dilate=replace_stride_with_dilation[0])
+        self.layer3 = self._make_layer(block, 256, layers[2], stride=2,
+                                       dilate=replace_stride_with_dilation[1])
+        self.layer4 = self._make_layer(block, 512, layers[3], stride=2,
+                                       dilate=replace_stride_with_dilation[2])
         self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
         self.fc = nn.Linear(512 * block.expansion, num_classes)
-        self.need_rep = need_rep
 
         for m in self.modules():
             if isinstance(m, nn.Conv2d):
-                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
-            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+            elif isinstance(m, (nn.BatchNorm2d, nn.GroupNorm)):
                 nn.init.constant_(m.weight, 1)
                 nn.init.constant_(m.bias, 0)
 
-    def _make_layer(self, block, planes, blocks, stride=1):
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck):
+                    nn.init.constant_(m.bn3.weight, 0)
+                elif isinstance(m, BasicBlock):
+                    nn.init.constant_(m.bn2.weight, 0)
+
+    def _make_layer(self, block, planes, blocks, stride=1, dilate=False):
+        norm_layer = self._norm_layer
         downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
         if stride != 1 or self.inplanes != planes * block.expansion:
             downsample = nn.Sequential(
                 conv1x1(self.inplanes, planes * block.expansion, stride),
-                nn.BatchNorm2d(planes * block.expansion),
+                norm_layer(planes * block.expansion),
             )
 
         layers = []
-        layers.append(block(self.inplanes, planes, stride, downsample))
+        layers.append(block(self.inplanes, planes, stride, downsample, self.groups,
+                            self.base_width, previous_dilation, norm_layer))
         self.inplanes = planes * block.expansion
         for _ in range(1, blocks):
-            layers.append(block(self.inplanes, planes))
+            layers.append(block(self.inplanes, planes, groups=self.groups,
+                                base_width=self.base_width, dilation=self.dilation,
+                                norm_layer=norm_layer))
 
         return nn.Sequential(*layers)
 
@@ -172,11 +213,7 @@ class ResNet(nn.Module):
         rep = x.view(x.size(0), -1)
         x = self.fc(rep)
 
-        if self.need_rep:
-            # return x, rep
-            return x, rep_l1, rep_l2, rep_l3, rep_l4, rep
-        else:
-            return x
+        return x, rep_l1, rep_l2, rep_l3, rep_l4, rep
 
 
 def resnet18(pretrained=False, **kwargs):
@@ -192,43 +229,47 @@ def resnet18(pretrained=False, **kwargs):
 
 def resnet34(pretrained=False, **kwargs):
     """Constructs a ResNet-34 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(BasicBlock, [3, 4, 6, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet34"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet34']))
     return model
 
 
 def resnet50(pretrained=False, **kwargs):
     """Constructs a ResNet-50 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(Bottleneck, [3, 4, 6, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet50"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet50']))
     return model
 
 
 def resnet101(pretrained=False, **kwargs):
     """Constructs a ResNet-101 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(Bottleneck, [3, 4, 23, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet101"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet101']))
     return model
 
 
 def resnet152(pretrained=False, **kwargs):
     """Constructs a ResNet-152 model.
+
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
     model = ResNet(Bottleneck, [3, 8, 36, 3], **kwargs)
     if pretrained:
-        model.load_state_dict(model_zoo.load_url(model_urls["resnet152"]))
+        model.load_state_dict(model_zoo.load_url(model_urls['resnet152']))
     return model


### PR DESCRIPTION
[Refactoring]: MCN모델 수정

- 모델 파라미터 수정 사항
  - need_rep 제거: 항상 각 레이어의 출력값을 계산하도록 변경
  - vocabulary 제거: 텍스트 데이터 미사용으로 인해 제거
  - vse_off 제거: 텍스트 데이터 미사용으로 인해 제거
  - mlp_layers 제거, hidden_sizes 추가: 레이어의 개수 지정 -> 레이어 크기 지정으로 변경
  - conv_frets 제거: 항상 모든 레이어의 추렭값을 계산하도록 변경
  - item_num 추가: 아이템 개수를 지정해줄 수 있도록 변경

- 모델 파라미터 수정에 따른 model config, get_model 수정
- MCN_Trainer 수정
  - vse_loss 삭제
  - 로스 계산 객체를 함수 지역변수에서 클래스 지역변수로 변경